### PR TITLE
Specify the AWS IoT SQL version

### DIFF
--- a/cross-account-publish/python/partner-account.yaml
+++ b/cross-account-publish/python/partner-account.yaml
@@ -12,6 +12,7 @@ Resources:
     Properties:
       TopicRulePayload:
         RuleDisabled: false
+        AwsIotSqlVersion: 2016-03-23
         Sql: !Join [ "", [ "SELECT *, concat(\"cross_account_publish/", !Ref "AWS::AccountId", "/\", regexp_replace(topic(), \"^[^/]*/[^/]*/\", \"\")) AS topic FROM 'cross_account_publish/", !Ref CustomerAccountParameter, "/#'" ] ]
         Actions:
           - Lambda:


### PR DESCRIPTION
SQL version 2016-03-23 has several fixes over the default 2015-10-08
version, including fixes for top-level arrays and nested objects.

*Issue #, if available:* [Issue #9](https://github.com/aws-samples/iot-reference-architectures/issues/9)

*Description of changes:*
* Added the AWS IoT SQL version to the IoT Rule definition, instead of letting the Rule get created with the default older SQL version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
